### PR TITLE
chore: promote nodey536 to version 1.0.4 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey536/nodey536-1.0.4-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey536/nodey536-1.0.4-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-11-05T10:07:34Z"
+  creationTimestamp: "2020-11-06T11:48:24Z"
   deletionTimestamp: null
-  name: 'nodey536-1.0.3'
+  name: 'nodey536-1.0.4'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -24,8 +24,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jstrachan
       message: |
-        release 1.0.3
-      sha: 169310fa8007ab7ebd20d0f18ad95f3af8f80ee5
+        release 1.0.4
+      sha: 14979ecb3bca9c95edb8f17ca02ea5a7e71681ac
     - author:
         accountReference:
           - id: jenkins-x-bot
@@ -40,8 +40,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jstrachan
       message: |
-        release 1.0.3
-      sha: 0041427a9f43774310a3e7667ca117b3b140c279
+        release 1.0.4
+      sha: 72a8ceafeda418d8ecd3486631df4378713ab030
     - author:
         accountReference:
           - id: james-strachan-0
@@ -51,18 +51,17 @@ spec:
       branch: master
       committer:
         accountReference:
-          - id: james-strachan-0
+          - id: github-0
             provider: jenkins.io/git-github-userid
-        email: james.strachan@gmail.com
-        name: James Strachan
-      message: |
-        fix: change title
-      sha: 090777c8c4730c4cd5864199e8f698507f572eb2
+        email: noreply@github.com
+        name: GitHub
+      message: Update triggers.yaml
+      sha: c479a57903b93e14b8545871591ffedbd95e2605
   gitCloneUrl: https://github.com/jstrachan/nodey536.git
   gitHttpUrl: https://github.com/jstrachan/nodey536
   gitOwner: jstrachan
   gitRepository: nodey536
   name: 'nodey536'
-  releaseNotesURL: https://github.com/jstrachan/nodey536/releases/tag/v1.0.3
-  version: v1.0.3
+  releaseNotesURL: https://github.com/jstrachan/nodey536/releases/tag/v1.0.4
+  version: v1.0.4
 status: {}

--- a/config-root/namespaces/jx-staging/nodey536/nodey536-nodey536-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey536/nodey536-nodey536-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey536-nodey536
   labels:
     draft: draft-app
-    chart: "nodey536-1.0.3"
+    chart: "nodey536-1.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: nodey536
-          image: "gcr.io/jenkins-x-labs-bdd/nodey536:1.0.3"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey536:1.0.4"
           imagePullPolicy: IfNotPresent
           env:
           envFrom: null

--- a/config-root/namespaces/jx-staging/nodey536/nodey536-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey536/nodey536-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey536
   labels:
-    chart: "nodey536-1.0.3"
+    chart: "nodey536-1.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -97,7 +97,7 @@ releases:
   values:
   - versionStream/charts/jx3/jx-build-controller/values.yaml.gotmpl
 - chart: dev/nodey536
-  version: 1.0.3
+  version: 1.0.4
   name: nodey536
   namespace: jx-staging
 - chart: jx3/jx-kh-check


### PR DESCRIPTION
chore: promote nodey536 to version 1.0.4 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge