### PR TITLE
chore: promote nodey536 to version 1.0.6 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey536/nodey536-1.0.6-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey536/nodey536-1.0.6-release.yaml
@@ -1,0 +1,64 @@
+# Source: nodey536/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-11-11T18:23:15Z"
+  deletionTimestamp: null
+  name: 'nodey536-1.0.6'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        release 1.0.6
+      sha: 6d4522d377cc362da8c576e14be99f035900ee75
+    - author:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        release 1.0.6
+      sha: 6598838fe946725897bae276b12bebbc5df8530b
+    - author:
+        accountReference:
+          - provider: jenkins.io/git-github-userid
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        accountReference:
+          - provider: jenkins.io/git-github-userid
+        email: noreply@github.com
+        name: GitHub
+      message: Update index.html
+      sha: 4dbc5fac4cfdd8b0e80f59a50948dc27beca142f
+  gitCloneUrl: https://github.com/jstrachan/nodey536.git
+  gitHttpUrl: https://github.com/jstrachan/nodey536
+  gitOwner: jstrachan
+  gitRepository: nodey536
+  name: 'nodey536'
+  releaseNotesURL: https://github.com/jstrachan/nodey536/releases/tag/v1.0.6
+  version: v1.0.6
+status: {}

--- a/config-root/namespaces/jx-staging/nodey536/nodey536-ingress.yaml
+++ b/config-root/namespaces/jx-staging/nodey536/nodey536-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: nodey536/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: nodey536
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey536
+              servicePort: 80
+      host: nodey536-jx-staging.35.184.150.204.nip.io

--- a/config-root/namespaces/jx-staging/nodey536/nodey536-nodey536-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey536/nodey536-nodey536-deploy.yaml
@@ -1,0 +1,55 @@
+# Source: nodey536/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodey536-nodey536
+  labels:
+    draft: draft-app
+    chart: "nodey536-1.0.6"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nodey536-nodey536
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: nodey536-nodey536
+    spec:
+      containers:
+        - name: nodey536
+          image: "gcr.io/jenkins-x-labs-bdd/nodey536:1.0.6"
+          imagePullPolicy: IfNotPresent
+          env:
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/nodey536/nodey536-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey536/nodey536-svc.yaml
@@ -1,0 +1,21 @@
+# Source: nodey536/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey536
+  labels:
+    chart: "nodey536-1.0.6"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey536-nodey536

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -23,6 +23,8 @@ repositories:
   url: https://charts.helm.sh/stable
 - name: choerodon
   url: https://openchart.choerodon.com.cn/choerodon/c7n
+- name: dev
+  url: http://chartmuseum-jx.35.184.150.204.nip.io/
 releases:
 - chart: jenkins-x/jxboot-helmfile-resources
   version: 1.0.12
@@ -98,5 +100,9 @@ releases:
   namespace: jx
   values:
   - versionStream/charts/jx3/health-checks-jx/values.yaml.gotmpl
+- chart: dev/nodey536
+  version: 1.0.6
+  name: nodey536
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""

--- a/jx-values.yaml
+++ b/jx-values.yaml
@@ -85,3 +85,9 @@ jxRequirements:
     ref: master
     url: https://github.com/jenkins-x/jxr-versions.git
   webhook: lighthouse
+jxRequirementsIngressExternalDNS:
+  enabled: false
+jxRequirementsIngressTLS:
+  enabled: false
+jxRequirementsVault:
+  enabled: false


### PR DESCRIPTION
chore: promote nodey536 to version 1.0.6 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge