### PR TITLE
chore: promote nodey534 to version 1.0.7 in Staging environment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -102,5 +102,9 @@ releases:
   version: 1.0.7
   name: nodey536
   namespace: jx-staging
+- chart: dev/nodey534
+  version: 1.0.7
+  name: nodey534
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote nodey534 to version 1.0.7 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge