### PR TITLE
chore: promote nodey533 to version 1.0.1 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey533/nodey533-1.0.1-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey533/nodey533-1.0.1-release.yaml
@@ -1,0 +1,67 @@
+# Source: nodey533/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-11-18T10:31:58Z"
+  deletionTimestamp: null
+  name: 'nodey533-1.0.1'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - id: jstrachan
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        accountReference:
+          - id: jstrachan
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        release 1.0.1
+      sha: 8d75fc02e79b19cb073dd41c3fac8d67ea902ba6
+    - author:
+        accountReference:
+          - id: jstrachan
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        accountReference:
+          - id: jstrachan
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        release 1.0.1
+      sha: cb5ac6d93efda25284f71f011f63e94fb90a2e4f
+    - author:
+        accountReference:
+          - id: james-strachan-0
+            provider: jenkins.io/git-github-userid
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        accountReference:
+          - id: github-0
+            provider: jenkins.io/git-github-userid
+        email: noreply@github.com
+        name: GitHub
+      message: Update index.html
+      sha: 2c6e634109c88f7025a3c5a75b2688088e50f3c1
+  gitCloneUrl: https://github.com/jstrachan/nodey533.git
+  gitHttpUrl: https://github.com/jstrachan/nodey533
+  gitOwner: jstrachan
+  gitRepository: nodey533
+  name: 'nodey533'
+  releaseNotesURL: https://github.com/jstrachan/nodey533/releases/tag/v1.0.1
+  version: v1.0.1
+status: {}

--- a/config-root/namespaces/jx-staging/nodey533/nodey533-ingress.yaml
+++ b/config-root/namespaces/jx-staging/nodey533/nodey533-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: nodey533/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: nodey533
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey533
+              servicePort: 80
+      host: nodey533-jx-staging.35.184.150.204.nip.io

--- a/config-root/namespaces/jx-staging/nodey533/nodey533-nodey533-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey533/nodey533-nodey533-deploy.yaml
@@ -1,0 +1,55 @@
+# Source: nodey533/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodey533-nodey533
+  labels:
+    draft: draft-app
+    chart: "nodey533-1.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nodey533-nodey533
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: nodey533-nodey533
+    spec:
+      containers:
+        - name: nodey533
+          image: "gcr.io/jenkins-x-labs-bdd/nodey533:1.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/nodey533/nodey533-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey533/nodey533-svc.yaml
@@ -1,0 +1,21 @@
+# Source: nodey533/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey533
+  labels:
+    chart: "nodey533-1.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey533-nodey533

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -19,6 +19,8 @@ repositories:
   url: https://storage.googleapis.com/jenkinsxio/charts
 - name: stable
   url: https://charts.helm.sh/stable
+- name: dev
+  url: http://chartmuseum-jx.35.184.150.204.nip.io/
 releases:
 - chart: jenkins-x/jxboot-helmfile-resources
   version: 1.0.16
@@ -94,5 +96,9 @@ releases:
   namespace: jx
   values:
   - versionStream/charts/jx3/health-checks-jx/values.yaml.gotmpl
+- chart: dev/nodey533
+  version: 1.0.1
+  name: nodey533
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote nodey533 to version 1.0.1 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge