### PR TITLE
chore: promote nodey536 to version 1.0.8 in Staging environment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -100,5 +100,9 @@ releases:
   version: 1.0.1
   name: nodey533
   namespace: jx-staging
+- chart: dev/nodey536
+  version: 1.0.8
+  name: nodey536
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote nodey536 to version 1.0.8 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge