### PR TITLE
chore: promote nodey542 to version 1.0.0 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey542/nodey542-1.0.0-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey542/nodey542-1.0.0-release.yaml
@@ -1,0 +1,84 @@
+# Source: nodey542/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-11-22T09:22:39Z"
+  deletionTimestamp: null
+  name: 'nodey542-1.0.0'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        release 1.0.0
+      sha: 807cd16b830ca976ee8bf0096de8295dca8bfff1
+    - author:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: added variables
+      sha: 0a8c9a53586dfc42d6f2dacc9960cef100a71dec
+    - author:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        release 1.0.0
+      sha: 29205d047a7d11bf130d3b46fe48ef8b9f1528d2
+    - author:
+        accountReference:
+          - id: james-strachan-0
+            provider: jenkins.io/git-github-userid
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        accountReference:
+          - id: james-strachan-0
+            provider: jenkins.io/git-github-userid
+        email: james.strachan@gmail.com
+        name: James Strachan
+      message: |
+        chore: Jenkins X build pack
+      sha: 0e2c4d4fa2adaae76045c8eec5edfd8aece58202
+  gitCloneUrl: https://github.com/jstrachan/nodey542.git
+  gitHttpUrl: https://github.com/jstrachan/nodey542
+  gitOwner: jstrachan
+  gitRepository: nodey542
+  name: 'nodey542'
+  releaseNotesURL: https://github.com/jstrachan/nodey542/releases/tag/v1.0.0
+  version: v1.0.0
+status: {}

--- a/config-root/namespaces/jx-staging/nodey542/nodey542-ingress.yaml
+++ b/config-root/namespaces/jx-staging/nodey542/nodey542-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: nodey542/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: nodey542
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey542
+              servicePort: 80
+      host: nodey542-jx-staging.35.184.150.204.nip.io

--- a/config-root/namespaces/jx-staging/nodey542/nodey542-nodey542-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey542/nodey542-nodey542-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: nodey542/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodey542-nodey542
+  labels:
+    draft: draft-app
+    chart: "nodey542-1.0.0"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nodey542-nodey542
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: nodey542-nodey542
+    spec:
+      serviceAccountName: nodey542-nodey542
+      containers:
+        - name: nodey542
+          image: "gcr.io/jenkins-x-labs-bdd/nodey542:1.0.0"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 1.0.0
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/nodey542/nodey542-nodey542-sa.yaml
+++ b/config-root/namespaces/jx-staging/nodey542/nodey542-nodey542-sa.yaml
@@ -1,0 +1,8 @@
+# Source: nodey542/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nodey542-nodey542
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/nodey542/nodey542-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey542/nodey542-svc.yaml
@@ -1,0 +1,21 @@
+# Source: nodey542/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey542
+  labels:
+    chart: "nodey542-1.0.0"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey542-nodey542

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -100,5 +100,9 @@ releases:
   version: 1.0.1
   name: nodey533
   namespace: jx-staging
+- chart: dev/nodey542
+  version: 1.0.0
+  name: nodey542
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote nodey542 to version 1.0.0 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge