### PR TITLE
chore: promote nodey542 to version 1.0.1 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey542/nodey542-1.0.1-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey542/nodey542-1.0.1-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-11-22T09:22:39Z"
+  creationTimestamp: "2020-11-23T06:46:39Z"
   deletionTimestamp: null
-  name: 'nodey542-1.0.0'
+  name: 'nodey542-1.0.1'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -24,8 +24,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        release 1.0.0
-      sha: 807cd16b830ca976ee8bf0096de8295dca8bfff1
+        release 1.0.1
+      sha: 80087dd656add3c741cb9141bd897327e2e87f83
     - author:
         accountReference:
           - id: jenkins-x-bot-0
@@ -41,7 +41,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: added variables
-      sha: 0a8c9a53586dfc42d6f2dacc9960cef100a71dec
+      sha: c2892f5831fbe2e80f824e44f39c64b6175eeb7b
     - author:
         accountReference:
           - id: jenkins-x-bot-0
@@ -56,8 +56,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        release 1.0.0
-      sha: 29205d047a7d11bf130d3b46fe48ef8b9f1528d2
+        release 1.0.1
+      sha: 0d6d654190a87be870cb562618fa9530244195f4
     - author:
         accountReference:
           - id: james-strachan-0
@@ -72,13 +72,13 @@ spec:
         email: james.strachan@gmail.com
         name: James Strachan
       message: |
-        chore: Jenkins X build pack
-      sha: 0e2c4d4fa2adaae76045c8eec5edfd8aece58202
+        fix: upgrade pipelines
+      sha: bd97ff185e501bdc919aa858b08c4b47deb97eba
   gitCloneUrl: https://github.com/jstrachan/nodey542.git
   gitHttpUrl: https://github.com/jstrachan/nodey542
   gitOwner: jstrachan
   gitRepository: nodey542
   name: 'nodey542'
-  releaseNotesURL: https://github.com/jstrachan/nodey542/releases/tag/v1.0.0
-  version: v1.0.0
+  releaseNotesURL: https://github.com/jstrachan/nodey542/releases/tag/v1.0.1
+  version: v1.0.1
 status: {}

--- a/config-root/namespaces/jx-staging/nodey542/nodey542-nodey542-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey542/nodey542-nodey542-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey542-nodey542
   labels:
     draft: draft-app
-    chart: "nodey542-1.0.0"
+    chart: "nodey542-1.0.1"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey542-nodey542
       containers:
         - name: nodey542
-          image: "gcr.io/jenkins-x-labs-bdd/nodey542:1.0.0"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey542:1.0.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.0
+              value: 1.0.1
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey542/nodey542-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey542/nodey542-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey542
   labels:
-    chart: "nodey542-1.0.0"
+    chart: "nodey542-1.0.1"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -101,7 +101,7 @@ releases:
   name: nodey533
   namespace: jx-staging
 - chart: dev/nodey542
-  version: 1.0.0
+  version: 1.0.1
   name: nodey542
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote nodey542 to version 1.0.1 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge