### PR TITLE
chore: promote nodey542 to version 1.0.7 in Staging environment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -101,7 +101,7 @@ releases:
   name: nodey533
   namespace: jx-staging
 - chart: dev/nodey542
-  version: 1.0.6
+  version: 1.0.7
   name: nodey542
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote nodey542 to version 1.0.7 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge