### PR TITLE
chore: promote nodey542 to version 2.0.1303 in Staging environment

### DIFF
--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -89,7 +89,7 @@ spec:
             $(inputs.params.subdirectory)'
           command:
           - /bin/sh
-          image: gcr.io/jenkinsxio/builder-jx:2.1.32-662
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.18.0
           name: git-clone
           resources: {}
           workingDir: /workspace

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -101,7 +101,7 @@ releases:
   name: nodey533
   namespace: jx-staging
 - chart: dev/nodey542
-  version: 1.0.6
+  version: 2.0.1303
   name: nodey542
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote nodey542 to version 2.0.1303 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge