### PR TITLE
chore: promote knative-quickstart to version 0.0.3 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/knative-quickstart/helloworld-go-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/helloworld-go-ksvc.yaml
@@ -1,0 +1,16 @@
+# Source: knative-quickstart/templates/helloworld-go-service.yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-go
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/jenkins-x-labs-bdd/helloworld-go:0.0.3@sha256:0979b3402a9340a2ca075124189d1bd9db1e62cd23c04938e4bceeddafe9f05d
+          env:
+            - name: TARGET
+              value: "Go Sample v1"

--- a/config-root/namespaces/jx-staging/knative-quickstart/helloworld-nodejs-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/helloworld-nodejs-ksvc.yaml
@@ -1,0 +1,16 @@
+# Source: knative-quickstart/templates/helloworld-nodejs-service.yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-nodejs
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/jenkins-x-labs-bdd/helloworld-nodejs:0.0.3@sha256:792af484771850a3e6bb19976e23e40f31cededc47245f5d61616dee81854294
+          env:
+            - name: TARGET
+              value: "Node.js Sample v1"

--- a/config-root/namespaces/jx-staging/knative-quickstart/helloworld-php-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/helloworld-php-ksvc.yaml
@@ -1,0 +1,16 @@
+# Source: knative-quickstart/templates/helloworld-php-service.yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-php
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/jenkins-x-labs-bdd/helloworld-php:0.0.3@sha256:60887ac83b462304f6aedbb2e86298474b8b86d12476dcf5620bdc8a20843848
+          env:
+            - name: TARGET
+              value: "PHP Sample v1"

--- a/config-root/namespaces/jx-staging/knative-quickstart/knative-quickstart-0.0.3-release.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/knative-quickstart-0.0.3-release.yaml
@@ -1,0 +1,52 @@
+# Source: knative-quickstart/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-11-27T15:24:32Z"
+  deletionTimestamp: null
+  name: 'knative-quickstart-0.0.3'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: added variables
+      sha: d776fb72519ae3248ebdd95ccc61a69b1db1be6f
+    - author:
+        accountReference:
+          - id: james-strachan-0
+            provider: jenkins.io/git-github-userid
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        accountReference:
+          - id: james-strachan-0
+            provider: jenkins.io/git-github-userid
+        email: james.strachan@gmail.com
+        name: James Strachan
+      message: |
+        chore: disable local kaniko
+      sha: 60fc772f2c796ab83a95d094b1caca602c72f6d1
+  gitCloneUrl: https://github.com/jstrachan/knative-quickstart.git
+  gitHttpUrl: https://github.com/jstrachan/knative-quickstart
+  gitOwner: jstrachan
+  gitRepository: knative-quickstart
+  name: 'knative-quickstart'
+  releaseNotesURL: https://github.com/jstrachan/knative-quickstart/releases/tag/v0.0.3
+  version: v0.0.3
+status: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -100,5 +100,9 @@ releases:
   namespace: jx
   values:
   - versionStream/charts/jx3/health-checks-jx/values.yaml.gotmpl
+- chart: dev/knative-quickstart
+  version: 0.0.3
+  name: knative-quickstart
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote knative-quickstart to version 0.0.3 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge