### PR TITLE
chore: promote knative-quickstart to version 0.0.8 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/knative-quickstart/helloworld-go-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/helloworld-go-ksvc.yaml
@@ -10,7 +10,7 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/jenkins-x-labs-bdd/helloworld-go:0.0.3@sha256:0979b3402a9340a2ca075124189d1bd9db1e62cd23c04938e4bceeddafe9f05d
+        - image: gcr.io/jenkins-x-labs-bdd/helloworld-go:0.0.8@sha256:7171a6907c895ee258d3c02ace2d0db9be02ca139660243c705c78f3f57beead
           env:
             - name: TARGET
               value: "Go Sample v1"

--- a/config-root/namespaces/jx-staging/knative-quickstart/helloworld-nodejs-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/helloworld-nodejs-ksvc.yaml
@@ -10,7 +10,7 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/jenkins-x-labs-bdd/helloworld-nodejs:0.0.3@sha256:792af484771850a3e6bb19976e23e40f31cededc47245f5d61616dee81854294
+        - image: gcr.io/jenkins-x-labs-bdd/helloworld-nodejs:0.0.8@sha256:905506658fe5a8ad39654652273f184b6ff963a19088348bedf526b2fabe0781
           env:
             - name: TARGET
               value: "Node.js Sample v1"

--- a/config-root/namespaces/jx-staging/knative-quickstart/helloworld-php-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/helloworld-php-ksvc.yaml
@@ -10,7 +10,7 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/jenkins-x-labs-bdd/helloworld-php:0.0.3@sha256:60887ac83b462304f6aedbb2e86298474b8b86d12476dcf5620bdc8a20843848
+        - image: gcr.io/jenkins-x-labs-bdd/helloworld-php:0.0.8@sha256:c2572cb5685c8d0e726d6a1b58fcd3fdb236fae7068534c6385f8da01b427afa
           env:
             - name: TARGET
               value: "PHP Sample v1"

--- a/config-root/namespaces/jx-staging/knative-quickstart/knative-quickstart-0.0.8-release.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/knative-quickstart-0.0.8-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-11-27T15:24:32Z"
+  creationTimestamp: "2020-11-27T16:42:46Z"
   deletionTimestamp: null
-  name: 'knative-quickstart-0.0.3'
+  name: 'knative-quickstart-0.0.8'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -25,7 +25,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: added variables
-      sha: d776fb72519ae3248ebdd95ccc61a69b1db1be6f
+      sha: e4518ac77108abbf1aec399d4799609f599ebfb2
     - author:
         accountReference:
           - id: james-strachan-0
@@ -40,13 +40,13 @@ spec:
         email: james.strachan@gmail.com
         name: James Strachan
       message: |
-        chore: disable local kaniko
-      sha: 60fc772f2c796ab83a95d094b1caca602c72f6d1
+        chore: use TaskRun for kaniko
+      sha: 7eb2f1d8e8b3262f8b2f0ee0b0ffd658090cd243
   gitCloneUrl: https://github.com/jstrachan/knative-quickstart.git
   gitHttpUrl: https://github.com/jstrachan/knative-quickstart
   gitOwner: jstrachan
   gitRepository: knative-quickstart
   name: 'knative-quickstart'
-  releaseNotesURL: https://github.com/jstrachan/knative-quickstart/releases/tag/v0.0.3
-  version: v0.0.3
+  releaseNotesURL: https://github.com/jstrachan/knative-quickstart/releases/tag/v0.0.8
+  version: v0.0.8
 status: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -101,7 +101,7 @@ releases:
   values:
   - versionStream/charts/jx3/health-checks-jx/values.yaml.gotmpl
 - chart: dev/knative-quickstart
-  version: 0.0.3
+  version: 0.0.8
   name: knative-quickstart
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote knative-quickstart to version 0.0.8 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge