### PR TITLE
chore: promote nodey536 to version 1.0.10 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey536/nodey536-1.0.10-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey536/nodey536-1.0.10-release.yaml
@@ -1,0 +1,83 @@
+# Source: nodey536/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-01T05:38:18Z"
+  deletionTimestamp: null
+  name: 'nodey536-1.0.10'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      message: |
+        fix: better changelog
+      sha: 6621b727f4c617bf3da7c3749e39c955ee52a8e6
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: noreply@github.com
+        name: GitHub
+      message: Update index.html
+      sha: 993414b6fbd70101a0e147e071b6f751839ce3c4
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: noreply@github.com
+        name: GitHub
+      message: Update index.html
+      sha: 7ac63643aebdd7bd564039318c9356cb1e661271
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: noreply@github.com
+        name: GitHub
+      message: Update index.html
+      sha: 4c0fa419b318be5bb9a981b3293c382e06e5f81e
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: noreply@github.com
+        name: GitHub
+      message: Update index.html
+      sha: 0846b54664545355d7cb99f48558c7b39a4b6984
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: noreply@github.com
+        name: GitHub
+      message: Update index.html
+      sha: a0c39bc826df65f47d70cccebf40abb5e864e4ea
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: noreply@github.com
+        name: GitHub
+      message: 'fix: awesomer'
+      sha: c6a3754bdddabe2cb8bff10e5458ecf2b5538d33
+  gitHttpUrl: https://github.com/jstrachan/nodey536
+  gitOwner: jstrachan
+  gitRepository: nodey536
+  name: 'nodey536'
+  releaseNotesURL: https://github.com/jstrachan/nodey536/releases/tag/v1.0.10
+  version: v1.0.10
+status: {}

--- a/config-root/namespaces/jx-staging/nodey536/nodey536-ingress.yaml
+++ b/config-root/namespaces/jx-staging/nodey536/nodey536-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: nodey536/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: nodey536
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey536
+              servicePort: 80
+      host: nodey536-jx-staging.35.184.150.204.nip.io

--- a/config-root/namespaces/jx-staging/nodey536/nodey536-nodey536-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey536/nodey536-nodey536-deploy.yaml
@@ -1,0 +1,55 @@
+# Source: nodey536/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodey536-nodey536
+  labels:
+    draft: draft-app
+    chart: "nodey536-1.0.10"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nodey536-nodey536
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: nodey536-nodey536
+    spec:
+      containers:
+        - name: nodey536
+          image: "gcr.io/jenkins-x-labs-bdd/nodey536:1.0.10"
+          imagePullPolicy: IfNotPresent
+          env:
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/nodey536/nodey536-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey536/nodey536-svc.yaml
@@ -1,0 +1,21 @@
+# Source: nodey536/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey536
+  labels:
+    chart: "nodey536-1.0.10"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey536-nodey536

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -108,5 +108,9 @@ releases:
   version: 2.0.1310
   name: nodey542
   namespace: jx-staging
+- chart: dev/nodey536
+  version: 1.0.10
+  name: nodey536
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote nodey536 to version 1.0.10 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge