### PR TITLE
chore: promote nodey536 to version 1.0.16 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey536/nodey536-1.0.16-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey536/nodey536-1.0.16-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-01T07:53:02Z"
+  creationTimestamp: "2020-12-02T08:37:37Z"
   deletionTimestamp: null
-  name: 'nodey536-1.0.15'
+  name: 'nodey536-1.0.16'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -19,21 +19,20 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: added variables
-      sha: 04bff63166066ceaa0c42746a1e005c9728fc604
+      sha: fe81b2dacccb6468aba2815974a3404daccd2582
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
       branch: master
       committer:
-        email: james.strachan@gmail.com
-        name: James Strachan
-      message: |
-        fix: changelog 7
-      sha: 7cdbe76adf8278ad7360718cfd696bac4c0fd028
+        email: noreply@github.com
+        name: GitHub
+      message: Update index.html
+      sha: 88d81c55f4576c247d8b12e9cbd8051512290511
   gitHttpUrl: https://github.com/jstrachan/nodey536
   gitOwner: jstrachan
   gitRepository: nodey536
   name: 'nodey536'
-  releaseNotesURL: https://github.com/jstrachan/nodey536/releases/tag/v1.0.15
-  version: v1.0.15
+  releaseNotesURL: https://github.com/jstrachan/nodey536/releases/tag/v1.0.16
+  version: v1.0.16
 status: {}

--- a/config-root/namespaces/jx-staging/nodey536/nodey536-nodey536-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey536/nodey536-nodey536-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey536-nodey536
   labels:
     draft: draft-app
-    chart: "nodey536-1.0.15"
+    chart: "nodey536-1.0.16"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: nodey536
-          image: "gcr.io/jenkins-x-labs-bdd/nodey536:1.0.15"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey536:1.0.16"
           imagePullPolicy: IfNotPresent
           env:
           envFrom: null

--- a/config-root/namespaces/jx-staging/nodey536/nodey536-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey536/nodey536-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey536
   labels:
-    chart: "nodey536-1.0.15"
+    chart: "nodey536-1.0.16"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -109,7 +109,7 @@ releases:
   name: nodey542
   namespace: jx-staging
 - chart: dev/nodey536
-  version: 1.0.15
+  version: 1.0.16
   name: nodey536
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote nodey536 to version 1.0.16 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge