### PR TITLE
chore: promote knative-quickstart to version 0.0.10 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/knative-quickstart/helloworld-go-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/helloworld-go-ksvc.yaml
@@ -1,0 +1,16 @@
+# Source: knative-quickstart/templates/helloworld-go-service.yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-go
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/jenkins-x-labs-bdd/helloworld-go:0.0.10@sha256:0b291794cb29d2ee356465e1b69ac4f9168f3dd0df79f083d4da265e085fd83f
+          env:
+            - name: TARGET
+              value: "Go Sample v1"

--- a/config-root/namespaces/jx-staging/knative-quickstart/helloworld-nodejs-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/helloworld-nodejs-ksvc.yaml
@@ -1,0 +1,16 @@
+# Source: knative-quickstart/templates/helloworld-nodejs-service.yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-nodejs
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/jenkins-x-labs-bdd/helloworld-nodejs:0.0.10@sha256:5e8432934c50ce1427c17a2d070398b6a1a9e5dfa18dad656df723e0c055e8d0
+          env:
+            - name: TARGET
+              value: "Node.js Sample v1"

--- a/config-root/namespaces/jx-staging/knative-quickstart/helloworld-php-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/helloworld-php-ksvc.yaml
@@ -1,0 +1,16 @@
+# Source: knative-quickstart/templates/helloworld-php-service.yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-php
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/jenkins-x-labs-bdd/helloworld-php:0.0.10@sha256:84b7b7703f1e874cace8c45e718b4d0dbe521b9bcdda591ff01ab5dc836cbc39
+          env:
+            - name: TARGET
+              value: "PHP Sample v1"

--- a/config-root/namespaces/jx-staging/knative-quickstart/knative-quickstart-0.0.10-release.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/knative-quickstart-0.0.10-release.yaml
@@ -1,0 +1,51 @@
+# Source: knative-quickstart/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-02T13:43:26Z"
+  deletionTimestamp: null
+  name: 'knative-quickstart-0.0.10'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: added variables
+      sha: 58043fd4e310dea6a8c42976b802b27c91bc5cb0
+    - author:
+        accountReference:
+          - id: james-strachan-0
+            provider: jenkins.io/git-github-userid
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        accountReference:
+          - id: github-0
+            provider: jenkins.io/git-github-userid
+        email: noreply@github.com
+        name: GitHub
+      message: Update index.js
+      sha: b1c13c53ba097301b804660e574e0f090f28c688
+  gitCloneUrl: https://github.com/jstrachan/knative-quickstart.git
+  gitHttpUrl: https://github.com/jstrachan/knative-quickstart
+  gitOwner: jstrachan
+  gitRepository: knative-quickstart
+  name: 'knative-quickstart'
+  releaseNotesURL: https://github.com/jstrachan/knative-quickstart/releases/tag/v0.0.10
+  version: v0.0.10
+status: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -21,6 +21,8 @@ repositories:
   url: https://charts.helm.sh/stable
 - name: istio
   url: https://jenkins-x-charts.github.io/istio
+- name: dev
+  url: http://chartmuseum-jx.35.184.150.204.nip.io/
 releases:
 - chart: istio/base
   name: base
@@ -118,5 +120,9 @@ releases:
   namespace: jx
   values:
   - versionStream/charts/jx3/health-checks-jx/values.yaml.gotmpl
+- chart: dev/knative-quickstart
+  version: 0.0.10
+  name: knative-quickstart
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote knative-quickstart to version 0.0.10 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge