### PR TITLE
chore: promote knative-quickstart to version 0.0.11 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/knative-quickstart/helloworld-go-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/helloworld-go-ksvc.yaml
@@ -10,7 +10,7 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/jenkins-x-labs-bdd/helloworld-go:0.0.10@sha256:0b291794cb29d2ee356465e1b69ac4f9168f3dd0df79f083d4da265e085fd83f
+        - image: gcr.io/jenkins-x-labs-bdd/helloworld-go:0.0.11@sha256:ee3a89dc891e920e535d0664b735ba1c111bdfeddc7556fb5f5713b4347908e5
           env:
             - name: TARGET
               value: "Go Sample v1"

--- a/config-root/namespaces/jx-staging/knative-quickstart/helloworld-nodejs-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/helloworld-nodejs-ksvc.yaml
@@ -10,7 +10,7 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/jenkins-x-labs-bdd/helloworld-nodejs:0.0.10@sha256:5e8432934c50ce1427c17a2d070398b6a1a9e5dfa18dad656df723e0c055e8d0
+        - image: gcr.io/jenkins-x-labs-bdd/helloworld-nodejs:0.0.11@sha256:7163b0da9ea84101fa2a615495c686ba0dc7cf8355311ee6acb9cb5a10d5b1aa
           env:
             - name: TARGET
               value: "Node.js Sample v1"

--- a/config-root/namespaces/jx-staging/knative-quickstart/helloworld-php-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/helloworld-php-ksvc.yaml
@@ -10,7 +10,7 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/jenkins-x-labs-bdd/helloworld-php:0.0.10@sha256:84b7b7703f1e874cace8c45e718b4d0dbe521b9bcdda591ff01ab5dc836cbc39
+        - image: gcr.io/jenkins-x-labs-bdd/helloworld-php:0.0.11@sha256:46b078ab2df794aaa3bd6f99ab497f9a36a936b72e405403eeca5a9485fc3409
           env:
             - name: TARGET
               value: "PHP Sample v1"

--- a/config-root/namespaces/jx-staging/knative-quickstart/knative-quickstart-0.0.11-release.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/knative-quickstart-0.0.11-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-02T13:43:26Z"
+  creationTimestamp: "2020-12-02T14:19:22Z"
   deletionTimestamp: null
-  name: 'knative-quickstart-0.0.10'
+  name: 'knative-quickstart-0.0.11'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -25,7 +25,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: added variables
-      sha: 58043fd4e310dea6a8c42976b802b27c91bc5cb0
+      sha: 38f9616f19cba6af74f53a06cd2e275650def60c
     - author:
         accountReference:
           - id: james-strachan-0
@@ -40,12 +40,12 @@ spec:
         email: noreply@github.com
         name: GitHub
       message: Update index.js
-      sha: b1c13c53ba097301b804660e574e0f090f28c688
+      sha: 1e05a0b61f29e3eea844c17febf4256d95a0c6d0
   gitCloneUrl: https://github.com/jstrachan/knative-quickstart.git
   gitHttpUrl: https://github.com/jstrachan/knative-quickstart
   gitOwner: jstrachan
   gitRepository: knative-quickstart
   name: 'knative-quickstart'
-  releaseNotesURL: https://github.com/jstrachan/knative-quickstart/releases/tag/v0.0.10
-  version: v0.0.10
+  releaseNotesURL: https://github.com/jstrachan/knative-quickstart/releases/tag/v0.0.11
+  version: v0.0.11
 status: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -121,7 +121,7 @@ releases:
   values:
   - versionStream/charts/jx3/health-checks-jx/values.yaml.gotmpl
 - chart: dev/knative-quickstart
-  version: 0.0.10
+  version: 0.0.11
   name: knative-quickstart
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote knative-quickstart to version 0.0.11 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge