### PR TITLE
chore: promote knative-quickstart to version 0.0.12 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/knative-quickstart/helloworld-go-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/helloworld-go-ksvc.yaml
@@ -10,7 +10,7 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/jenkins-x-labs-bdd/helloworld-go:0.0.11@sha256:ee3a89dc891e920e535d0664b735ba1c111bdfeddc7556fb5f5713b4347908e5
+        - image: gcr.io/jenkins-x-labs-bdd/helloworld-go:0.0.12@sha256:96c13368c468f8c95c139d4c2ad4248fda76ef89785da15a1d3947aacab90e29
           env:
             - name: TARGET
               value: "Go Sample v1"

--- a/config-root/namespaces/jx-staging/knative-quickstart/helloworld-nodejs-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/helloworld-nodejs-ksvc.yaml
@@ -10,7 +10,7 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/jenkins-x-labs-bdd/helloworld-nodejs:0.0.11@sha256:7163b0da9ea84101fa2a615495c686ba0dc7cf8355311ee6acb9cb5a10d5b1aa
+        - image: gcr.io/jenkins-x-labs-bdd/helloworld-nodejs:0.0.12@sha256:5ffc284831e1093cc7ea02ef9a3c196bb638da750e56a9b565f40333c5bc82de
           env:
             - name: TARGET
               value: "Node.js Sample v1"

--- a/config-root/namespaces/jx-staging/knative-quickstart/helloworld-php-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/helloworld-php-ksvc.yaml
@@ -10,7 +10,7 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/jenkins-x-labs-bdd/helloworld-php:0.0.11@sha256:46b078ab2df794aaa3bd6f99ab497f9a36a936b72e405403eeca5a9485fc3409
+        - image: gcr.io/jenkins-x-labs-bdd/helloworld-php:0.0.12@sha256:ffd837d3f3286b5313de7e599d263ad0585f69ff450fd1ef431d09a7036a8825
           env:
             - name: TARGET
               value: "PHP Sample v1"

--- a/config-root/namespaces/jx-staging/knative-quickstart/knative-quickstart-0.0.12-release.yaml
+++ b/config-root/namespaces/jx-staging/knative-quickstart/knative-quickstart-0.0.12-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-02T14:19:22Z"
+  creationTimestamp: "2020-12-02T14:52:06Z"
   deletionTimestamp: null
-  name: 'knative-quickstart-0.0.11'
+  name: 'knative-quickstart-0.0.12'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -25,7 +25,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: added variables
-      sha: 38f9616f19cba6af74f53a06cd2e275650def60c
+      sha: f88415498be1229b24cec5390d89d7c79193b153
     - author:
         accountReference:
           - id: james-strachan-0
@@ -39,13 +39,13 @@ spec:
             provider: jenkins.io/git-github-userid
         email: noreply@github.com
         name: GitHub
-      message: Update index.js
-      sha: 1e05a0b61f29e3eea844c17febf4256d95a0c6d0
+      message: Update README.md
+      sha: 3d4da7d75dab8a512a1a0b4da2816b914b4e4090
   gitCloneUrl: https://github.com/jstrachan/knative-quickstart.git
   gitHttpUrl: https://github.com/jstrachan/knative-quickstart
   gitOwner: jstrachan
   gitRepository: knative-quickstart
   name: 'knative-quickstart'
-  releaseNotesURL: https://github.com/jstrachan/knative-quickstart/releases/tag/v0.0.11
-  version: v0.0.11
+  releaseNotesURL: https://github.com/jstrachan/knative-quickstart/releases/tag/v0.0.12
+  version: v0.0.12
 status: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -124,7 +124,7 @@ releases:
   values:
   - versionStream/charts/jx3/health-checks-jx/values.yaml.gotmpl
 - chart: dev/knative-quickstart
-  version: 0.0.11
+  version: 0.0.12
   name: knative-quickstart
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote knative-quickstart to version 0.0.12 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge