### PR TITLE
chore: promote nodey544 to version 1.0.1 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey544/nodey544-1.0.1-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey544/nodey544-1.0.1-release.yaml
@@ -1,0 +1,39 @@
+# Source: nodey544/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-07T11:54:19Z"
+  deletionTimestamp: null
+  name: 'nodey544-1.0.1'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 4644d1572a9819e9c36b367a9defc66b51154ee9
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      message: |
+        chore: Jenkins X build pack
+      sha: ef6868ac636fc6801f140ab294e602b8626f40d7
+  gitHttpUrl: https://github.com/jstrachan/nodey544
+  gitOwner: jstrachan
+  gitRepository: nodey544
+  name: 'nodey544'
+  releaseNotesURL: https://github.com/jstrachan/nodey544/releases/tag/v1.0.1
+  version: v1.0.1
+status: {}

--- a/config-root/namespaces/jx-staging/nodey544/nodey544-ingress.yaml
+++ b/config-root/namespaces/jx-staging/nodey544/nodey544-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: nodey544/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: nodey544
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey544
+              servicePort: 80
+      host: nodey544-jx.34.105.200.93.nip.io

--- a/config-root/namespaces/jx-staging/nodey544/nodey544-nodey544-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey544/nodey544-nodey544-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: nodey544/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodey544-nodey544
+  labels:
+    draft: draft-app
+    chart: "nodey544-1.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nodey544-nodey544
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: nodey544-nodey544
+    spec:
+      serviceAccountName: nodey544-nodey544
+      containers:
+        - name: nodey544
+          image: "gcr.io/jenkins-x-labs-bdd/nodey544:1.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 1.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/nodey544/nodey544-nodey544-sa.yaml
+++ b/config-root/namespaces/jx-staging/nodey544/nodey544-nodey544-sa.yaml
@@ -1,0 +1,8 @@
+# Source: nodey544/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nodey544-nodey544
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/nodey544/nodey544-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey544/nodey544-svc.yaml
@@ -1,0 +1,21 @@
+# Source: nodey544/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey544
+  labels:
+    chart: "nodey544-1.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey544-nodey544

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -1,9 +1,15 @@
 filepath: ""
 helmfiles:
 - path: helmfiles/jx/helmfile.yaml
+  environment: {}
 - path: helmfiles/nginx/helmfile.yaml
+  environment: {}
 - path: helmfiles/secret-infra/helmfile.yaml
+  environment: {}
 - path: helmfiles/tekton-pipelines/helmfile.yaml
+  environment: {}
+- path: helmfiles/jx-staging/helmfile.yaml
+  environment: {}
 templates: {}
 missingFileHandler: ""
 renderedvalues: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -1,15 +1,10 @@
 filepath: ""
 helmfiles:
 - path: helmfiles/jx/helmfile.yaml
-  environment: {}
 - path: helmfiles/nginx/helmfile.yaml
-  environment: {}
 - path: helmfiles/secret-infra/helmfile.yaml
-  environment: {}
 - path: helmfiles/tekton-pipelines/helmfile.yaml
-  environment: {}
 - path: helmfiles/jx-staging/helmfile.yaml
-  environment: {}
 templates: {}
 missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -1,0 +1,14 @@
+filepath: ""
+namespace: jx-staging
+repositories:
+- name: dev
+  url: http://chartmuseum-jx.34.105.200.93.nip.io/
+releases:
+- chart: dev/nodey544
+  version: 1.0.1
+  name: nodey544
+  forceNamespace: ""
+  skipDeps: null
+templates: {}
+missingFileHandler: ""
+renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey544 to version 1.0.1 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge